### PR TITLE
For content locations without basename, use id

### DIFF
--- a/unmht.py
+++ b/unmht.py
@@ -28,7 +28,8 @@ def extract_mhtml(file_path: str, output_dir: str="."):
 
         if content_location:
             filename = os.path.basename(content_location)
-        else:
+
+        if not filename:
             ext = os.path.basename(content_type)
             filename = os.path.basename(content_id) + "." + ext
 


### PR DESCRIPTION
- Some MHTML content locations may be URLs to directories, ending with a forward slash (`/`).
- Directory locations yield empty basenames in `os.path.basename()`, which results in an empty filename and later a file write error.
  - > Note that the result of this function is different from the Unix basename program; where basename for '/foo/bar/' returns 'bar', the basename() function returns an empty string ('').
- For empty locations basenames, fall back to the content id-based a filename.

See

- https://docs.python.org/3/library/os.path.html
- https://en.wikipedia.org/wiki/Basename